### PR TITLE
_BASE_URL now read from environmental variable with default value

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 setup(name='solcast',
-      version='0.2.0',
+      version='0.2.1',
       description='Client library for the Solcast API',
       license='MIT',
       url='https://github.com/cjtapper/solcast-py',

--- a/solcast/base.py
+++ b/solcast/base.py
@@ -1,3 +1,4 @@
+import os as _os
 import logging
 import time
 from urllib.parse import urljoin
@@ -6,7 +7,7 @@ import requests
 
 from solcast import api_key
 
-_BASE_URL = 'https://api.solcast.com.au/'
+_BASE_URL = _os.getenv('SOLCAST_BASE_URL', 'https://api.solcast.com.au/')
 
 class Base(object):
 


### PR DESCRIPTION
_BASE_URL should not be hardcoded. It should be possible to update it through environmental variable.

This is for two reasons:

- Service base URL may change in the future
- Users may want to test their application using a mocked server for Solcast